### PR TITLE
Add `#include <assert.h>` to make it build

### DIFF
--- a/backends/lakeroad/lakeroad.cc
+++ b/backends/lakeroad/lakeroad.cc
@@ -26,6 +26,7 @@
 #include "kernel/sigtools.h"
 #include "kernel/yw.h"
 #include <string>
+#include <assert.h>
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN


### PR DESCRIPTION
The build will fail (at least for me) due to the `assert`s in the `lakeroad.cc` file.