### PR TITLE
Allow `write_lakeroad` backend to write output to file instead of stdout.

### DIFF
--- a/backends/lakeroad/example.ys
+++ b/backends/lakeroad/example.ys
@@ -6,3 +6,5 @@ EOF
 
 # Write output to file instead of stdout
 write_lakeroad file.egg
+# Write output to stdout
+# write_lakeroad

--- a/backends/lakeroad/example.ys
+++ b/backends/lakeroad/example.ys
@@ -4,4 +4,5 @@ module test(input [1:0] a, input b, output o);
 endmodule
 EOF
 
-write_lakeroad
+# Write output to file instead of stdout
+write_lakeroad file.egg

--- a/backends/lakeroad/example.ys
+++ b/backends/lakeroad/example.ys
@@ -4,7 +4,8 @@ module test(input [1:0] a, input b, output o);
 endmodule
 EOF
 
-# Write output to file instead of stdout
-write_lakeroad file.egg
 # Write output to stdout
-# write_lakeroad
+write_lakeroad
+# Write output to file.egg
+write_lakeroad file.egg
+!rm file.egg

--- a/backends/lakeroad/lakeroad.cc
+++ b/backends/lakeroad/lakeroad.cc
@@ -1716,8 +1716,7 @@ struct BtorBackend : public Backend {
 		log_header(design, "Executing Lakeroad egglog backend.\n");
 		RTLIL::Module *topmod = design->top_module();
 
-		// Copied from firrtl code. Not sure why "filename" is not set ever
-		// even when I pass "write_lakeroad hello.egg" or something
+		// Copied from firrtl code.
 		size_t argidx = args.size();
 
 		if (filename == "") {

--- a/backends/lakeroad/lakeroad.cc
+++ b/backends/lakeroad/lakeroad.cc
@@ -25,8 +25,8 @@
 #include "kernel/rtlil.h"
 #include "kernel/sigtools.h"
 #include "kernel/yw.h"
-#include <string>
 #include <assert.h>
+#include <string>
 
 USING_YOSYS_NAMESPACE
 PRIVATE_NAMESPACE_BEGIN
@@ -1714,11 +1714,24 @@ struct BtorBackend : public Backend {
 	void execute(std::ostream *&f, std::string filename, std::vector<std::string> args, RTLIL::Design *design) override
 	{
 		log_header(design, "Executing Lakeroad egglog backend.\n");
-
 		RTLIL::Module *topmod = design->top_module();
 
+		// Copied from firrtl code. Not sure why "filename" is not set ever
+		// even when I pass "write_lakeroad hello.egg" or something
+		size_t argidx = args.size(); // We aren't expecting any arguments.
+
 		// Has to come after other arg parsing.
-		extra_args(f, filename, args, args.size());
+		if (filename == "") {
+			if (argidx > 0 && args[argidx - 1][0] != '-') {
+				// extra_args and friends need to see this argument.
+				argidx -= 1;
+				filename = args[argidx];
+			}
+		}
+
+		extra_args(f, filename, args, argidx);
+
+		// log("Given filename: %s", args.c_str());
 
 		if (topmod == nullptr)
 			log_cmd_error("No top module found.\n");

--- a/backends/lakeroad/lakeroad.cc
+++ b/backends/lakeroad/lakeroad.cc
@@ -1718,20 +1718,19 @@ struct BtorBackend : public Backend {
 
 		// Copied from firrtl code. Not sure why "filename" is not set ever
 		// even when I pass "write_lakeroad hello.egg" or something
-		size_t argidx = args.size(); // We aren't expecting any arguments.
+		size_t argidx = args.size();
 
-		// Has to come after other arg parsing.
 		if (filename == "") {
-			if (argidx > 0 && args[argidx - 1][0] != '-') {
+			// The command itself is given as an arg
+			if (argidx > 1 && args[argidx - 1][0] != '-') {
 				// extra_args and friends need to see this argument.
 				argidx -= 1;
 				filename = args[argidx];
 			}
 		}
 
+		// Has to come after other arg parsing.
 		extra_args(f, filename, args, argidx);
-
-		// log("Given filename: %s", args.c_str());
 
 		if (topmod == nullptr)
 			log_cmd_error("No top module found.\n");


### PR DESCRIPTION
Add code to allow `write_lakeroad` backend to write to file instead of stdout. 

Example (in `example.ys`):
```
read_verilog <<EOF
module test(input [1:0] a, input b, output o);
  assign o = a & b;
endmodule
EOF

# Write output to file instead of stdout
write_lakeroad file.egg
```
@gussmith23